### PR TITLE
HoYoPlay v1.1.4.133

### DIFF
--- a/HoYoPlay/1.1.4.133.md
+++ b/HoYoPlay/1.1.4.133.md
@@ -1,0 +1,4 @@
+---
+
+**[升级包 | HoYoPlay | to 1.1.4.133](https://hyp-webstatic.hoyoverse.com/hyp-client/VYTpXlbWo8_1.1.4.133_1_0_cps_hyp_global_VYTpXlbWo8_7hoyoverse_202408152029_ccwReIuz.zip)**
+

--- a/HoYoPlay/1.1.4.133.md
+++ b/HoYoPlay/1.1.4.133.md
@@ -1,4 +1,12 @@
+**[Installer | HoYoPlay | Web](https://download-porter.hoyoverse.com/download-porter/2024/08/26/VYTpXlbWo8_1.1.4.133_1_0_hyp_hoyoverse_prod_202408152031_ulMVEyOh%20%281%29.exe)**
+
+**[Installer | GenshinImpact | Web](https://download-porter.hoyoverse.com/download-porter/2024/08/14/GenshinImpact_install_202407301502.exe)**
+
+**[Installer | HonkaiStarRail | Web](https://download-porter.hoyoverse.com/download-porter/2024/08/15/2.3_0815_setup_hoyoverse.exe)**
+
+**[Installer | ZenlessZoneZero | Web](https://download-porter.hoyoverse.com/download-porter/2024/08/19/ZenlessZoneZero_setup_20240802172225_CUeKVd52z8A1QA95_202408021555.exe)**
+
 ---
 
-**[升级包 | HoYoPlay | to 1.1.4.133](https://hyp-webstatic.hoyoverse.com/hyp-client/VYTpXlbWo8_1.1.4.133_1_0_cps_hyp_global_VYTpXlbWo8_7hoyoverse_202408152029_ccwReIuz.zip)**
+**[Upgrade Pack | HoYoPlay | to 1.1.4.133](https://hyp-webstatic.hoyoverse.com/hyp-client/VYTpXlbWo8_1.1.4.133_1_0_cps_hyp_global_VYTpXlbWo8_7hoyoverse_202408152029_ccwReIuz.zip)**
 

--- a/米哈游启动器/1.1.4.133.md
+++ b/米哈游启动器/1.1.4.133.md
@@ -1,0 +1,4 @@
+
+---
+
+**[升级包 | 米哈游启动器 | to 1.1.4.133](https://hyp-webstatic.mihoyo.com/hyp-client/jGHBHlcOq1_1.1.4.133_1_1_cps_hyp_cn_jGHBHlcOq1_11mihoyo_202408152023_EWWBxaYA.zip)**

--- a/米哈游启动器/1.1.4.133.md
+++ b/米哈游启动器/1.1.4.133.md
@@ -2,3 +2,9 @@
 ---
 
 **[升级包 | 米哈游启动器 | to 1.1.4.133](https://hyp-webstatic.mihoyo.com/hyp-client/jGHBHlcOq1_1.1.4.133_1_1_cps_hyp_cn_jGHBHlcOq1_11mihoyo_202408152023_EWWBxaYA.zip)**
+
+**[升级包 | 原神 | Bilibili渠道服 | to 1.1.4.133](https://hyp-webstatic.mihoyo.com/hyp-client/umfgRO5gh5_1.1.4.133_14_0_cps_hk4e_cn_umfgRO5gh5_6mihoyo_202407301910_IYvEgOro.zip)**
+
+**[升级包 | 崩坏：星穹铁道 | Bilibili渠道服 | to 1.1.4.133](https://hyp-webstatic.mihoyo.com/hyp-client/6P5gHMNyK3_1.1.4.133_14_0_cps_hkrpg_cn_6P5gHMNyK3_12mihoyo_202407251127_zuFesEwy.zip)**
+
+**[升级包 | 绝区零 | Bilibili渠道服 | to 1.1.4.133](https://hyp-webstatic.mihoyo.com/hyp-client/yBg0VrTLtk_1.1.4.133_14_0_cps_nap_cn_yBg0VrTLtk_4mihoyo_202408021713_EVAWUAbI.zip)**

--- a/米哈游启动器/1.1.4.133.md
+++ b/米哈游启动器/1.1.4.133.md
@@ -1,3 +1,19 @@
+**[安装包 | 米哈游启动器 | 官网](https://hyp-webstatic.mihoyo.com/hyp-client/hyp_cn_setup_1.1.4.exe)**
+
+**[安装包 | 崩坏3 | 官网](https://autopatchcn.bh3.com/ptpublic/rel/20240808171859_ZbbpINVg96sAoHB3/Bh3_release_1.1.4.133_gw_pc.exe)**
+
+**[安装包 | 原神 | 官网](https://autopatchcn.yuanshen.com/client_app/download/launcher/20240802154502_1DHdTgDU71FMVFGN/mihoyo/yuanshen_setup_202407301658.exe)**
+
+**[安装包 | 原神 | Bilibili渠道服](https://pkg.biligame.com/games/yuanshen_setup_202407301911/069788/yuanshen_setup_202407301911.exe)**
+
+**[安装包 | 崩坏星穹铁道 | 官网](https://autopatchcn.bhsr.com/client/cn/20240725121148_Y6OTV2k6lnCKbUUO/gw/StarRail_setup_1.1.4.exe)**
+
+**[安装包 | 崩坏星穹铁道 | Bilibili渠道服](https://pkg.biligame.com/games/StarRail_setup_bilibili/773823/StarRail_setup_bilibili.exe)**
+
+**[安装包 | 绝区零 | 官网](https://autopatchcn.juequling.com/package_download/op/client_app/download/20240802174850_VWL0aLFcPn4kKXjS/gwpc/ZenlessZoneZero_setup_202408021630.exe)**
+
+**[安装包 | 绝区零 | Bilibili渠道服](https://pkg.biligame.com/games/zzz_bilibili_1.1new/840833/zzz_bilibili_1.1new.exe)**
+
 
 ---
 


### PR DESCRIPTION
### 更新时间 / Update Time
2024-08-19
### 更新内容 / Update Details
1.新增退出游戏后弹出启动器的可选选项。可以在“设置-米哈游启动器客户端”进行设置。
2.修复部分已知问题。

1.Adds an optional setting to open the launcher after exiting the game. This can be configured in "Settings > HoYoPlay Client."
2.Fixes some known issues.

### 其他更新内容
- 更新了 `设置-关于` 页面的内容排版。
- 更新了设置的icon。
- 更新了设置页面内的字体