### PR TITLE
HoYoPlay v1.5.2.229

### DIFF
--- a/HoYoPlay/1.5.2.229.md
+++ b/HoYoPlay/1.5.2.229.md
@@ -1,7 +1,7 @@
 ### Installer
 
 **HoYoPlay 
-[Website]()**
+Unknown**
 
 **Genshin Impact 
 [Website](https://download-porter.hoyoverse.com/download-porter/2025/03/27/GenshinImpact_install_202503072011.exe)**

--- a/HoYoPlay/1.5.2.229.md
+++ b/HoYoPlay/1.5.2.229.md
@@ -1,2 +1,21 @@
+### Installer
+
+**HoYoPlay 
+[Website]()**
+
+**Genshin Impact 
+[Website](https://download-porter.hoyoverse.com/download-porter/2025/03/27/GenshinImpact_install_202503072011.exe)**
+
+**Honkai: Star Rail 
+[Website](https://download-porter.hoyoverse.com/download-porter/2025/03/27/3.2_0327_setup_hoyoverse.exe)**
+
+**Zenless Zone Zero
+[Website](https://download-porter.hoyoverse.com/download-porter/2025/03/29/20250324175954_rToKo5BMdDH0jzBfZenlessZoneZero_setup_202503241500.exe)**
+
+**Honkai Impact 3rd
+[Website](https://autopatchglb.honkaiimpact3.com/ptpublic/bh3_hoyoplay/20250312141404_llg0JmCuCVuMV4hE/VYTpXlbWo8_1.5.2.229_1_0_hi3_gw_pc_prod_202503111125_HNtHEpCo.exe)**
+
+---
+
 ### Update Package
 **[HoYoPlay](https://hyp-webstatic.hoyoverse.com/hyp-client/VYTpXlbWo8_1.5.2.229_1_0_cps_hyp_global_VYTpXlbWo8_20hoyoverse_202503251048_cTZwNCNT.zip)**

--- a/渠道服/1.5.2.229.md
+++ b/渠道服/1.5.2.229.md
@@ -6,7 +6,7 @@
 
 ### 原神 / Genshin Impact
 **Bilibili渠道服 
-[安装程序]() | 
+[安装程序](https://pkg.biligame.com/games/yuanshen_setup_202503071932/811529/yuanshen_setup_202503071932.exe) | 
 [升级包](https://hyp-webstatic.mihoyo.com/hyp-client/umfgRO5gh5_1.5.2.229_14_0_cps_hk4e_cn_umfgRO5gh5_15mihoyo_202503071931_BLJIepbe.zip)**
 
 **Google Play

--- a/渠道服/1.5.2.229.md
+++ b/渠道服/1.5.2.229.md
@@ -16,12 +16,12 @@
 
 ### 崩坏：星穹铁道
 **Bilibili渠道服 
-[安装程序]() | 
+[安装程序](https://pkg.biligame.com/games/StarRail-20250331/446954/StarRail-20250331.exe) | 
 [升级包](https://hyp-webstatic.mihoyo.com/hyp-client/6P5gHMNyK3_1.5.2.229_14_0_cps_hkrpg_cn_6P5gHMNyK3_20mihoyo_202503071934_neVJnLgn.zip)**
 
 ---
 
 ### 绝区零
 **Bilibili渠道服 
-[安装程序]() | 
+[安装程序](https://pkg.biligame.com/games/ZenlessZoneZero_setup_202503241445/228795/ZenlessZoneZero_setup_202503241445.exe) | 
 [升级包](https://hyp-webstatic.mihoyo.com/hyp-client/xV0f4r1GT0_1.5.2.229_14_0_cps_nap_cn_xV0f4r1GT0_7mihoyo_202503241445_CYuRGFlC.zip)**

--- a/渠道服/1.5.2.229.md
+++ b/渠道服/1.5.2.229.md
@@ -1,0 +1,27 @@
+### 崩坏3 / Honkai Impact 3rd
+**Google Play
+[Update Package](https://hyp-webstatic.hoyoverse.com/hyp-client/ACQazS79kX_1.5.2.229_1_6_cps_bh3_global_ACQazS79kX_5hoyoverse_202503111513_BpgYNOcT.zip)**
+
+---
+
+### 原神 / Genshin Impact
+**Bilibili渠道服 
+[安装程序]() | 
+[升级包](https://hyp-webstatic.mihoyo.com/hyp-client/umfgRO5gh5_1.5.2.229_14_0_cps_hk4e_cn_umfgRO5gh5_15mihoyo_202503071931_BLJIepbe.zip)**
+
+**Google Play
+[Update Package](https://hyp-webstatic.hoyoverse.com/hyp-client/8fANlj5K7I_1.5.2.229_1_6_cps_hk4e_global_8fANlj5K7I_17hoyoverse_202503072007_BRyWtLMZ.zip)**
+
+---
+
+### 崩坏：星穹铁道
+**Bilibili渠道服 
+[安装程序]() | 
+[升级包](https://hyp-webstatic.mihoyo.com/hyp-client/6P5gHMNyK3_1.5.2.229_14_0_cps_hkrpg_cn_6P5gHMNyK3_20mihoyo_202503071934_neVJnLgn.zip)**
+
+---
+
+### 绝区零
+**Bilibili渠道服 
+[安装程序]() | 
+[升级包](https://hyp-webstatic.mihoyo.com/hyp-client/xV0f4r1GT0_1.5.2.229_14_0_cps_nap_cn_xV0f4r1GT0_7mihoyo_202503241445_CYuRGFlC.zip)**

--- a/米哈游启动器/1.5.2.229.md
+++ b/米哈游启动器/1.5.2.229.md
@@ -1,6 +1,6 @@
 ### 安装程序
 **米哈游启动器
-[官网](https://hyp-webstatic.mihoyo.com/hyp-client/hyp_cn_setup_1.5.2.exe)**
+未知**
 
 **崩坏3
 [官网](https://autopatchcn.bh3.com/ptpublic/rel/20250407113058_8BF90etBY84v1Fqd/Bh3_release_1.5.2.229_gw_pc.exe)**

--- a/米哈游启动器/1.5.2.229.md
+++ b/米哈游启动器/1.5.2.229.md
@@ -1,2 +1,21 @@
+### 安装程序
+**米哈游启动器
+[官网](https://hyp-webstatic.mihoyo.com/hyp-client/hyp_cn_setup_1.5.2.exe)**
+
+**崩坏3
+[官网](https://autopatchcn.bh3.com/ptpublic/rel/20250407113058_8BF90etBY84v1Fqd/Bh3_release_1.5.2.229_gw_pc.exe)**
+
+**原神
+[官网](https://autopatchcn.yuanshen.com/client_app/download/launcher/20250317181110_rtA8y57iZNFVnGJx/mihoyo/yuanshen_setup_202503072031.exe)**
+
+**崩坏：星穹铁道
+[官网](https://autopatchcn.bhsr.com/client/cn/20250317183241_lhOtRZWQ64Sza68d/gw_PC/StarRail_setup_1.5.2.exe)**
+
+**绝区零
+[官网](https://autopatchcn.juequling.com/package_download/op/client_app/download/20250324175258_GO21zPUn69HuWpUk/ZenlessZoneZero_setup_202503241614.exe)**
+
+
+---
+
 ### 升级包
 **[米哈游启动器](https://hyp-webstatic.mihoyo.com/hyp-client/jGHBHlcOq1_1.5.2.229_1_1_cps_hyp_cn_jGHBHlcOq1_26mihoyo_202503251041_VLcnpbKA.zip)**


### PR DESCRIPTION
### 更新时间 / Update Time
2025-04-18
### 更新内容 / Update Details
1、优化了定位游戏功能。本地已有游戏资源，但游戏详情页主按钮仍展示“获取游戏”时，您可以点击主按钮下方的“定位游戏”，或前往游戏设置页点击“重新定位游戏”，以尝试解决该问题。
2、修复了米哈游启动器的部分已知问题。

1.Optimizes the Find Games function. When game resources are available locally, but the main button on the game details page continues to display "Get Game," you can click on "Find Games" under the main button, or head to the settings page and click on "Relocate Game" to try and resolve the issue.
2.Fixes some known issues in HoYoPlay.