### PR TITLE
HoYoPlay v1.7.3.261

### DIFF
--- a/HoYoPlay/1.4.2.199.md
+++ b/HoYoPlay/1.4.2.199.md
@@ -3,6 +3,9 @@
 **HoYoPlay 
 [Website](https://download-porter.hoyoverse.com/download-porter/2025/01/14/VYTpXlbWo8_1.4.2.199_1_0_hyp_hoyoverse_prod_202501021059_rmFvwOfI.exe)**
 
+**Honkai Impact 3rd
+[Website](https://autopatchglb.honkaiimpact3.com/ptpublic/bh3_hoyoplay/20241223174445_fiCU7oYR9fnE4cUm/VYTpXlbWo8_1.4.2.199_1_0_hi3_gw_pc_prod_202412231203_AeccJQyl.exe)**
+
 **Genshin Impact 
 [Website](https://download-porter.hoyoverse.com/download-porter/2025/01/02/GenshinImpact_install_202412201651.exe)**
 
@@ -11,9 +14,6 @@
 
 **Zenless Zone Zero
 [Website](https://download-porter.hoyoverse.com/download-porter/2025/01/02/20241223182713_rmIs1fCkmstzGU5A_ZenlessZoneZero_setup_202412231853.exe)**
-
-**Honkai Impact 3rd
-[Website](https://autopatchglb.honkaiimpact3.com/ptpublic/bh3_hoyoplay/20241223174445_fiCU7oYR9fnE4cUm/VYTpXlbWo8_1.4.2.199_1_0_hi3_gw_pc_prod_202412231203_AeccJQyl.exe)**
 
 ---
 

--- a/HoYoPlay/1.4.5.222.md
+++ b/HoYoPlay/1.4.5.222.md
@@ -3,12 +3,11 @@
 **HoYoPlay 
 [Website](https://download-porter.hoyoverse.com/download-porter/2025/02/21/VYTpXlbWo8_1.4.5.222_1_0_hyp_hoyoverse_prod_202502081529_XFGRLkBk.exe)**
 
+**Honkai Impact 3rd
+[Website](https://autopatchglb.honkaiimpact3.com/ptpublic/bh3_hoyoplay/20250210153138_pRdYy2BHJujKmXcK/VYTpXlbWo8_1.4.5.222_1_0_hi3_gw_pc_prod_202502101059_MoxIkcFj.exe)**
 
 **Honkai: Star Rail 
 [Website](https://download-porter.hoyoverse.com/download-porter/2025/02/10/3.0_0210_setup_hoyoverse.exe)**
-
-**Honkai Impact 3rd
-[Website](https://autopatchglb.honkaiimpact3.com/ptpublic/bh3_hoyoplay/20250210153138_pRdYy2BHJujKmXcK/VYTpXlbWo8_1.4.5.222_1_0_hi3_gw_pc_prod_202502101059_MoxIkcFj.exe)**
 
 ---
 

--- a/HoYoPlay/1.5.2.229.md
+++ b/HoYoPlay/1.5.2.229.md
@@ -3,6 +3,9 @@
 **HoYoPlay 
 Unknown**
 
+**Honkai Impact 3rd
+[Website](https://autopatchglb.honkaiimpact3.com/ptpublic/bh3_hoyoplay/20250312141404_llg0JmCuCVuMV4hE/VYTpXlbWo8_1.5.2.229_1_0_hi3_gw_pc_prod_202503111125_HNtHEpCo.exe)**
+
 **Genshin Impact 
 [Website](https://download-porter.hoyoverse.com/download-porter/2025/03/27/GenshinImpact_install_202503072011.exe)**
 
@@ -11,9 +14,6 @@ Unknown**
 
 **Zenless Zone Zero
 [Website](https://download-porter.hoyoverse.com/download-porter/2025/03/29/20250324175954_rToKo5BMdDH0jzBfZenlessZoneZero_setup_202503241500.exe)**
-
-**Honkai Impact 3rd
-[Website](https://autopatchglb.honkaiimpact3.com/ptpublic/bh3_hoyoplay/20250312141404_llg0JmCuCVuMV4hE/VYTpXlbWo8_1.5.2.229_1_0_hi3_gw_pc_prod_202503111125_HNtHEpCo.exe)**
 
 ---
 

--- a/HoYoPlay/1.7.3.261.md
+++ b/HoYoPlay/1.7.3.261.md
@@ -1,4 +1,20 @@
 ### Installer
+
+**HoYoPlay 
+Unknown**
+
+**Honkai Impact 3rd
+[Website]()**
+
+**Genshin Impact 
+[Website](https://download-porter.hoyoverse.com/download-porter/2025/05/16/GenshinImpact_install_202504281655.exe)**
+
+**Honkai: Star Rail 
+[Website](https://download-porter.hoyoverse.com/download-porter/2025/05/06/3.3_0506_setup_hoyoverse.exe)**
+
+**Zenless Zone Zero
+[Website](https://download-porter.hoyoverse.com/download-porter/2025/05/17/ZenlessZoneZero_setup_202504291527.exe)**
+
 ---
 
 ### Update Package

--- a/HoYoPlay/1.7.3.261.md
+++ b/HoYoPlay/1.7.3.261.md
@@ -1,0 +1,5 @@
+### Installer
+---
+
+### Update Package
+**[HoYoPlay](https://hyp-webstatic.hoyoverse.com/hyp-client/VYTpXlbWo8_1.7.3.261_1_1_cps_hyp_global_VYTpXlbWo8_21hoyoverse_202505081105_YXxcagMy.zip)**

--- a/HoYoPlay/1.7.3.261.md
+++ b/HoYoPlay/1.7.3.261.md
@@ -4,7 +4,7 @@
 Unknown**
 
 **Honkai Impact 3rd
-[Website]()**
+[Website](https://autopatchglb.honkaiimpact3.com/ptpublic/bh3_hoyoplay/20250428155901_IB5kGcZ1VaUiJKoP/VYTpXlbWo8_1.7.3.261_1_0_hi3_gw_pc_prod_202504281519_oGqyXqYq.exe)**
 
 **Genshin Impact 
 [Website](https://download-porter.hoyoverse.com/download-porter/2025/05/16/GenshinImpact_install_202504281655.exe)**

--- a/渠道服/1.7.3.261.md
+++ b/渠道服/1.7.3.261.md
@@ -1,0 +1,27 @@
+### 崩坏3 / Honkai Impact 3rd
+**Google Play
+[Update Package](https://hyp-webstatic.hoyoverse.com/hyp-client/ACQazS79kX_1.7.3.261_1_6_cps_bh3_global_ACQazS79kX_6hoyoverse_202504281605_juaPhYLh.zip)**
+
+---
+
+### 原神 / Genshin Impact
+**Bilibili渠道服 
+[安装程序]() | 
+[升级包](https://hyp-webstatic.mihoyo.com/hyp-client/umfgRO5gh5_1.7.3.261_14_0_cps_hk4e_cn_umfgRO5gh5_16mihoyo_202504251949_TMwNJvMc.zip)**
+
+**Google Play
+[Update Package](https://hyp-webstatic.hoyoverse.com/hyp-client/8fANlj5K7I_1.7.3.261_1_6_cps_hk4e_global_8fANlj5K7I_19hoyoverse_202504281655_UcacbguI.zip)**
+
+---
+
+### 崩坏：星穹铁道
+**Bilibili渠道服 
+[安装程序]() | 
+[升级包](https://hyp-webstatic.mihoyo.com/hyp-client/6P5gHMNyK3_1.7.3.261_14_0_cps_hkrpg_cn_6P5gHMNyK3_21mihoyo_202504271645_EjAMQhQE.zip)**
+
+---
+
+### 绝区零
+**Bilibili渠道服 
+[安装程序]() | 
+[升级包](https://hyp-webstatic.mihoyo.com/hyp-client/xV0f4r1GT0_1.7.3.261_14_0_cps_nap_cn_xV0f4r1GT0_8mihoyo_202504281126_rnCSekVn.zip)**

--- a/渠道服/1.7.3.261.md
+++ b/渠道服/1.7.3.261.md
@@ -6,7 +6,7 @@
 
 ### 原神 / Genshin Impact
 **Bilibili渠道服 
-[安装程序]() | 
+[安装程序](https://pkg.biligame.com/games/yuanshen_setup_202504251951/084464/yuanshen_setup_202504251951.exe) | 
 [升级包](https://hyp-webstatic.mihoyo.com/hyp-client/umfgRO5gh5_1.7.3.261_14_0_cps_hk4e_cn_umfgRO5gh5_16mihoyo_202504251949_TMwNJvMc.zip)**
 
 **Google Play
@@ -16,12 +16,12 @@
 
 ### 崩坏：星穹铁道
 **Bilibili渠道服 
-[安装程序]() | 
+[安装程序](https://pkg.biligame.com/games/StarRail-20250522/247127/StarRail-20250522.exe) | 
 [升级包](https://hyp-webstatic.mihoyo.com/hyp-client/6P5gHMNyK3_1.7.3.261_14_0_cps_hkrpg_cn_6P5gHMNyK3_21mihoyo_202504271645_EjAMQhQE.zip)**
 
 ---
 
 ### 绝区零
 **Bilibili渠道服 
-[安装程序]() | 
+[安装程序](https://pkg.biligame.com/games/ZenlessZoneZero_setup_202504281128/872347/ZenlessZoneZero_setup_202504281128.exe) | 
 [升级包](https://hyp-webstatic.mihoyo.com/hyp-client/xV0f4r1GT0_1.7.3.261_14_0_cps_nap_cn_xV0f4r1GT0_8mihoyo_202504281126_rnCSekVn.zip)**

--- a/米哈游启动器/1.7.3.261.md
+++ b/米哈游启动器/1.7.3.261.md
@@ -3,7 +3,7 @@
 未知**
 
 **崩坏3
-[官网]()**
+[官网](https://autopatchcn.bh3.com/ptpublic/rel/20250527174058_khr4waKjqCQhrceP/Bh3_release_1.7.3.261_official_pc.exe)**
 
 **原神
 [官网](https://autopatchcn.yuanshen.com/client_app/download/launcher/20250508182406_qVf7ZaTdA9uIdSJ7/mihoyo/yuanshen_setup_202504252217.exe)**

--- a/米哈游启动器/1.7.3.261.md
+++ b/米哈游启动器/1.7.3.261.md
@@ -1,0 +1,6 @@
+### 安装程序
+
+---
+
+### 升级包
+**[米哈游启动器](https://hyp-webstatic.mihoyo.com/hyp-client/jGHBHlcOq1_1.7.3.261_1_1_cps_hyp_cn_jGHBHlcOq1_27mihoyo_202505081113_ZehegatX.zip)**

--- a/米哈游启动器/1.7.3.261.md
+++ b/米哈游启动器/1.7.3.261.md
@@ -1,4 +1,19 @@
 ### 安装程序
+**米哈游启动器
+未知**
+
+**崩坏3
+[官网]()**
+
+**原神
+[官网](https://autopatchcn.yuanshen.com/client_app/download/launcher/20250508182406_qVf7ZaTdA9uIdSJ7/mihoyo/yuanshen_setup_202504252217.exe)**
+
+**崩坏：星穹铁道
+[官网](https://autopatchcn.bhsr.com/client/cn/20250429145008_SrRdunjgY4zAMEMV/gw_PC/StarRail_setup_1.7.3.exe)**
+
+**绝区零
+[官网](https://autopatchcn.juequling.com/package_download/op/client_app/download/20250516175916_DM6Xj4BK4SESBqyJ/zzz_gw_pc/ZenlessZoneZero_setup_202504281527.exe)**
+
 
 ---
 


### PR DESCRIPTION
### 更新时间 / Update Time
2025-05-14
### 更新内容 / Update Details
1、优化了启动器的卸载功能，更新完成后可以直接通过Windows控制面板​卸载游戏。
2、修复了米哈游启动器的部分已知问题。

1.Optimizes the Uninstall function. After the update is complete, you can uninstall the game directly through the Windows Control Panel.
2.Fixes some known issues in HoYoPlay.

### 其他更新内容
- 更新了 `游戏设置-卸载游戏` 页面的样式。
- 更新了 `启动器信息` 页面的样式，新增 `高级设置` 入口。
- 新增 `高级设置` 页面，新增 `使用代理服务器` `http协议降级开关` 两项功能。
> 使用代理服务器
> 启用后，米哈游启动器将优先使用当前的代理服务器进行下载。如您单独使用了加速器等产品，在下载缓慢时可尝试开启此配置。

> http协议降级开关
> 启用后，米哈游启动器将不再基于http2建立连接，通常您无需修改此配置
- 启动米哈游启动器时不会自动创建 `games` 子文件夹。